### PR TITLE
Fetch hyperliquid account balance

### DIFF
--- a/get_balance.py
+++ b/get_balance.py
@@ -7,7 +7,7 @@ def get_hyperliquid_balance():
     Fetch account balance from Hyperliquid exchange.
     
     Requires environment variables:
-        HL_API: Hyperliquid API key
+        HL_API: Hyperliquid API key (wallet address)
         HL_SECRET: Hyperliquid secret key
     
     Returns:
@@ -25,11 +25,12 @@ def get_hyperliquid_balance():
         'apiKey': api_key,
         'secret': secret_key,
         'enableRateLimit': True,
+        'walletAddress': api_key,  # Use the API key as wallet address
     })
     
     try:
-        # Fetch account balance
-        balance = exchange.fetch_balance()
+        # Fetch account balance with user parameter
+        balance = exchange.fetch_balance({'user': api_key})
         
         return balance
         


### PR DESCRIPTION
Add `get_balance.py` to fetch Hyperliquid account balance using `ccxt` and environment variables `HL_API` and `HL_SECRET`.

The initial implementation failed because Hyperliquid's `ccxt` integration requires the `walletAddress` in the exchange configuration and a `user` parameter in `fetch_balance`, both set to the `HL_API` (wallet address). This update ensures correct authentication and balance retrieval.

---
[Slack Thread](https://smoothbrainquant.slack.com/archives/C09JN2NLKB8/p1759701129734349?thread_ts=1759701129.734349&cid=C09JN2NLKB8)

<a href="https://cursor.com/background-agent?bcId=bc-062dd989-df1f-4370-b755-6c3cadedd555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-062dd989-df1f-4370-b755-6c3cadedd555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

