### PR TITLE
Prepend ccxt_ to all code

### DIFF
--- a/ccxt_api_test.py
+++ b/ccxt_api_test.py
@@ -2,7 +2,7 @@ import ccxt
 from datetime import datetime, timedelta
 import pandas as pd
 
-def fetch_hyperliquid_daily_data(symbols=['BTC/USDC:USDC', 'ETH/USDC:USDC', 'SOL/USDC:USDC'], days=5):
+def ccxt_fetch_hyperliquid_daily_data(symbols=['BTC/USDC:USDC', 'ETH/USDC:USDC', 'SOL/USDC:USDC'], days=5):
     """
     Fetch daily OHLCV data from Hyperliquid for specified symbols.
     
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     print("=" * 60)
     
     # Fetch data for BTC, ETH, and SOL
-    data = fetch_hyperliquid_daily_data(
+    data = ccxt_fetch_hyperliquid_daily_data(
         symbols=['BTC/USDC:USDC', 'ETH/USDC:USDC', 'SOL/USDC:USDC'],
         days=5
     )

--- a/ccxt_get_balance.py
+++ b/ccxt_get_balance.py
@@ -2,7 +2,7 @@ import ccxt
 import os
 from pprint import pprint
 
-def get_hyperliquid_balance():
+def ccxt_get_hyperliquid_balance():
     """
     Fetch account balance from Hyperliquid exchange.
     Fetches both perp (swap) and spot account balances.
@@ -45,7 +45,7 @@ def get_hyperliquid_balance():
         print(f"Error fetching balance: {str(e)}")
         raise
 
-def print_balance_summary(balances):
+def ccxt_print_balance_summary(balances):
     """
     Print a formatted summary of the account balance.
     
@@ -149,10 +149,10 @@ if __name__ == "__main__":
         print("Fetching Hyperliquid account balance (Perp + Spot)...")
         
         # Fetch balance
-        balances = get_hyperliquid_balance()
+        balances = ccxt_get_hyperliquid_balance()
         
         # Print formatted summary
-        print_balance_summary(balances)
+        ccxt_print_balance_summary(balances)
         
         # Optionally print full balance details
         print("\nFull Balance Details:")

--- a/ccxt_get_data.py
+++ b/ccxt_get_data.py
@@ -2,7 +2,7 @@ import ccxt
 from datetime import datetime, timedelta
 import pandas as pd
 
-def fetch_hyperliquid_daily_data(symbols=['BTC/USDC:USDC', 'ETH/USDC:USDC', 'SOL/USDC:USDC'], days=5):
+def ccxt_fetch_hyperliquid_daily_data(symbols=['BTC/USDC:USDC', 'ETH/USDC:USDC', 'SOL/USDC:USDC'], days=5):
     """
     Fetch daily OHLCV data from Hyperliquid for specified symbols.
     
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     print("=" * 60)
     
     # Fetch data for BTC, ETH, and SOL
-    data = fetch_hyperliquid_daily_data(
+    data = ccxt_fetch_hyperliquid_daily_data(
         symbols=['BTC/USDC:USDC', 'ETH/USDC:USDC', 'SOL/USDC:USDC'],
         days=5
     )

--- a/ccxt_get_positions.py
+++ b/ccxt_get_positions.py
@@ -1,7 +1,7 @@
 import ccxt
 import os
 
-def get_positions():
+def ccxt_get_positions():
     """
     Fetch account positions from Hyperliquid using API credentials.
     
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     print("=" * 60)
     
     try:
-        positions = get_positions()
+        positions = ccxt_get_positions()
         print(f"\nFound {len(positions)} positions:")
         for pos in positions:
             if pos.get('contracts', 0) != 0:  # Only show non-zero positions

--- a/ccxt_make_order.py
+++ b/ccxt_make_order.py
@@ -3,7 +3,7 @@ import os
 import argparse
 from pprint import pprint
 
-def make_order(symbol, notional_amount, side, order_type, price=None):
+def ccxt_make_order(symbol, notional_amount, side, order_type, price=None):
     """
     Place a market or limit order on Hyperliquid exchange.
     
@@ -126,7 +126,7 @@ def make_order(symbol, notional_amount, side, order_type, price=None):
         print(f"\n✗ Error placing order: {str(e)}")
         raise
 
-def main():
+def ccxt_main():
     """
     Command-line interface for placing orders.
     """
@@ -167,7 +167,7 @@ Environment Variables Required:
     
     try:
         # Place the order
-        order = make_order(
+        order = ccxt_make_order(
             symbol=args.symbol,
             notional_amount=args.notional,
             side=args.side,
@@ -193,4 +193,4 @@ Environment Variables Required:
         exit(1)
 
 if __name__ == "__main__":
-    main()
+    ccxt_main()


### PR DESCRIPTION
Rename all Python files and functions by prepending "ccxt_" to their original names as requested by the user.

---
[Slack Thread](https://smoothbrainquant.slack.com/archives/C09JN2NLKB8/p1759745165727099?thread_ts=1759745165.727099&cid=C09JN2NLKB8)

<a href="https://cursor.com/background-agent?bcId=bc-4a661145-57aa-4bff-a06a-dc7586e31c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a661145-57aa-4bff-a06a-dc7586e31c3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

